### PR TITLE
Grant hosts write access to archive blob storage

### DIFF
--- a/modules/archive/main.tf
+++ b/modules/archive/main.tf
@@ -151,3 +151,10 @@ resource "azurerm_storage_account_customer_managed_key" "example" {
     azurerm_key_vault_access_policy.sa
   ]
 }
+
+# Grant blob writer permissions on storage container
+resource "azurerm_role_assignment" "archive_blob_writer" {
+  scope                = azurerm_storage_container.archive.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = "<TODO principal id of cluster host role>"
+}


### PR DESCRIPTION
Looks like AWS grants write access to host in the `provision` module with a wildcard:

```tf
resource "aws_iam_policy" "vespa_cloud_host_policy" {
  name = "vespa-cloud-host-policy"
  policy = jsonencode({
    Version = "2012-10-17",
    Statement = [
      { # Allow hosts to upload to their archive bucket
        Effect = "Allow"
        Action = [
          "s3:PutObject",
          "s3:PutObjectTagging",
        ]
        Resource = "arn:aws:s3:::vespa-archive-*"
      }
      # [ ... omitted ... ]
    ]
  })
  tags = {
    managedby = "vespa-cloud"
  }
}
```

Makes more sense to do this in the archive module IMO and pass the host principal as a parameter

TODO draft PR just to remember this