### PR TITLE
Add storage account read access to provisioner

### DIFF
--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -64,6 +64,7 @@ resource "azurerm_role_definition" "provisioner" {
       "Microsoft.Network/loadBalancers/delete",
       "Microsoft.Network/publicIPAddresses/delete",
       "Microsoft.Compute/skus/read",
+      "Microsoft.Storage/storageAccounts/read"
     ]
   }
 }


### PR DESCRIPTION
```
2025-09-22 19:28:27.293 | WARNING: 
Failed to find enclave archive bucket for enclave azure account in subscription 'EnclaveAzureSubscription[accountId=<redacted>]' and zone 'dev.azure-eastus-az1': 
ai.vespa.hosted.azure.AzureApiException: 
The client '<redacted>' with object id '<redacted>' does not have authorization to perform action 'Microsoft.Storage/storageAccounts/read' over scope '/subscriptions/<redacted>/resourceGroups/dev.eastus-az1/providers/Microsoft.Storage' or the scope is invalid. 
If access was recently granted, please refresh your credentials.
```