### PR TITLE
Tag system RG with id-operator client ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
   # This is used by github actions to tag releases. Bump whenever making non-trivial changes.
   # Documentation changes are NOT considered minor and should bump the version.
   # To skip tagging for truly minor changes, mark the PR with a 'no-tag' label or start the PR title with 'minor'.
-  template_version = "1.0.24"
+  template_version = "1.0.25"
 
   issuer_url = var.__zts_url
 

--- a/operator.tf
+++ b/operator.tf
@@ -29,6 +29,18 @@ resource "azurerm_federated_identity_credential" "id_operator" {
   subject             = "user.${each.value}"
 }
 
+// Expose the id-operator client ID as a tag on the system resource group.
+// Uses azapi_update_resource to avoid a circular dependency (id_operator depends on system RG).
+resource "azapi_update_resource" "system_operator_tag" {
+  type        = "Microsoft.Resources/resourceGroups@2024-03-01"
+  resource_id = azurerm_resource_group.system.id
+  body = {
+    tags = {
+      vespa_operator_client_id = azurerm_user_assigned_identity.id_operator.client_id
+    }
+  }
+}
+
 resource "azurerm_role_definition" "bastion_vm_connect_reader" {
   name        = "vespa-operator-${data.azurerm_subscription.current.subscription_id}"
   scope       = data.azurerm_subscription.current.id


### PR DESCRIPTION
Add `vespa_operator_client_id` tag to the system resource group, exposing the
id-operator managed identity's client ID for discovery by the controller.

Uses `azapi_update_resource` to avoid a circular dependency: the system RG and
id_operator identity reference each other (identity lives in the RG, tag references
the identity's client ID).

Bumps template_version to 1.0.25.