### PR TITLE
Fix operator client ID tag being wiped on apply

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
   # This is used by github actions to tag releases. Bump whenever making non-trivial changes.
   # Documentation changes are NOT considered minor and should bump the version.
   # To skip tagging for truly minor changes, mark the PR with a 'no-tag' label or start the PR title with 'minor'.
-  template_version = "1.0.25"
+  template_version = "1.0.26"
 
   issuer_url = var.__zts_url
 

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,10 @@ resource "azurerm_resource_group" "system" {
   name     = "system"
   location = local.main_region
   tags     = merge(local.default_tags, { vespa_template_version = local.template_version })
+
+  lifecycle {
+    ignore_changes = [tags["vespa_operator_client_id"]]
+  }
 }
 
 // Uses the azapi provider to enable Encryption at Host feature for the subscription.


### PR DESCRIPTION
The `azurerm` provider resets system RG tags to the explicit set on every apply, wiping the `vespa_operator_client_id` tag added by `azapi_update_resource` in #71.

Add `ignore_changes = [tags["vespa_operator_client_id"]]` to the system RG lifecycle block so the azurerm provider leaves that tag alone.