### PR TITLE
Prevent azurerm from wiping operator client ID tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
   # This is used by github actions to tag releases. Bump whenever making non-trivial changes.
   # Documentation changes are NOT considered minor and should bump the version.
   # To skip tagging for truly minor changes, mark the PR with a 'no-tag' label or start the PR title with 'minor'.
-  template_version = "1.0.26"
+  template_version = "1.0.27"
 
   issuer_url = var.__zts_url
 

--- a/main.tf
+++ b/main.tf
@@ -31,10 +31,11 @@ locals {
 resource "azurerm_resource_group" "system" {
   name     = "system"
   location = local.main_region
-  tags     = merge(local.default_tags, { vespa_template_version = local.template_version })
 
+  // Tags are managed by azapi_update_resource in operator.tf to avoid a
+  // circular dependency with id_operator (whose client_id is included as a tag).
   lifecycle {
-    ignore_changes = [tags["vespa_operator_client_id"]]
+    ignore_changes = [tags]
   }
 }
 

--- a/operator.tf
+++ b/operator.tf
@@ -29,15 +29,17 @@ resource "azurerm_federated_identity_credential" "id_operator" {
   subject             = "user.${each.value}"
 }
 
-// Expose the id-operator client ID as a tag on the system resource group.
-// Uses azapi_update_resource to avoid a circular dependency (id_operator depends on system RG).
-resource "azapi_update_resource" "system_operator_tag" {
+// All system RG tags are managed here (not on the azurerm_resource_group) to avoid a
+// circular dependency: id_operator depends on the system RG, and we need id_operator's
+// client_id as a tag. The azurerm_resource_group uses ignore_changes = [tags].
+resource "azapi_update_resource" "system_rg_tags" {
   type        = "Microsoft.Resources/resourceGroups@2024-03-01"
   resource_id = azurerm_resource_group.system.id
   body = {
-    tags = {
+    tags = merge(local.default_tags, {
+      vespa_template_version   = local.template_version
       vespa_operator_client_id = azurerm_user_assigned_identity.id_operator.client_id
-    }
+    })
   }
 }
 


### PR DESCRIPTION
The `ignore_changes` on a specific map key (#72) didn't work: the azurerm provider still resets system RG tags to the explicit set on every apply, wiping the `vespa_operator_client_id` tag added by `azapi_update_resource` in #71.

Fix: move all system RG tag management to `azapi_update_resource` and use `ignore_changes = [tags]` on the `azurerm_resource_group` so the azurerm provider never touches tags.