### PR TITLE
Remove deprecated __operators variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
   # This is used by github actions to tag releases. Bump whenever making non-trivial changes.
   # Documentation changes are NOT considered minor and should bump the version.
   # To skip tagging for truly minor changes, mark the PR with a 'no-tag' label or start the PR title with 'minor'.
-  template_version = "1.0.27"
+  template_version = "1.0.28"
 
   issuer_url = var.__zts_url
 

--- a/operator.tf
+++ b/operator.tf
@@ -18,17 +18,6 @@ resource "azurerm_federated_identity_credential" "operator_service" {
   subject             = "${local.athenz_domain}.vespa-operator"
 }
 
-// Deprecated: Per-user federated credentials. Use vespa-operator service identity instead.
-resource "azurerm_federated_identity_credential" "id_operator" {
-  for_each            = toset(var.__operators)
-  name                = "operator-${each.value}"
-  parent_id           = azurerm_user_assigned_identity.id_operator.id
-  resource_group_name = azurerm_resource_group.system.name
-  issuer              = local.issuer_url
-  audience            = ["${local.athenz_domain}:${local.athenz_operator_role}"]
-  subject             = "user.${each.value}"
-}
-
 // All system RG tags are managed here (not on the azurerm_resource_group) to avoid a
 // circular dependency: id_operator depends on the system RG, and we need id_operator's
 // client_id as a tag. The azurerm_resource_group uses ignore_changes = [tags].

--- a/variables.tf
+++ b/variables.tf
@@ -23,10 +23,3 @@ variable "__zts_url" {
   default     = "https://zts.athenz.vespa-cloud.com:4443/zts/v1"
 }
 
-// Deprecated: Per-user operator principals. Use vespa-operator Athenz service identity instead.
-// Kept for backwards compatibility; will be removed in a future major version.
-variable "__operators" {
-  description = "Deprecated. Internal, do not override."
-  type        = list(string)
-  default     = []
-}


### PR DESCRIPTION
Remove the deprecated per-user operator federated credentials and `__operators` variable. These were replaced by the single `vespa-operator` Athenz service identity in #70, and were never used by the existing SSH tooling.

- Remove `azurerm_federated_identity_credential.id_operator` (per-user `for_each` block)
- Remove `__operators` variable from `variables.tf`
- Bump template_version to 1.0.28