### PR TITLE
Allow provisioner role to read/write disks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
   # This is used by github actions to tag releases. Bump whenever making non-trivial changes.
   # Documentation changes are NOT considered minor and should bump the version.
   # To skip tagging for truly minor changes, mark the PR with a 'no-tag' label or start the PR title with 'minor'.
-  template_version = "1.0.28"
+  template_version = "1.0.29"
 
   issuer_url = var.__zts_url
 

--- a/provisioner.tf
+++ b/provisioner.tf
@@ -24,6 +24,8 @@ resource "azurerm_role_definition" "provisioner" {
   permissions {
     actions = [
       "Microsoft.Compute/diskEncryptionSets/read",
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/disks/write",
       "Microsoft.Compute/virtualMachines/read",
       "Microsoft.Network/networkInterfaces/read",
       "Microsoft.Compute/virtualMachines/write",


### PR DESCRIPTION
Adds `Microsoft.Compute/disks/{read,write}` to the `vespa-provisioner` custom role so that `CloudResourceTagMaintainer` can reconcile custom resource tags on managed disks attached to enclave VMs.

Without these permissions the maintainer fails with `403 AuthorizationFailed` on `Microsoft.Compute/disks/read` when calling `AzureComputeClientImpl.reconcileDiskTags` (`getByResourceGroup` + `beginUpdate`).

The role is assigned at subscription scope; no assignment changes needed.

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)