### PR TITLE
Enforce SMB 3.1.1 on zone archive storage account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
   # This is used by github actions to tag releases. Bump whenever making non-trivial changes.
   # Documentation changes are NOT considered minor and should bump the version.
   # To skip tagging for truly minor changes, mark the PR with a 'no-tag' label or start the PR title with 'minor'.
-  template_version = "1.0.29"
+  template_version = "1.0.30"
 
   issuer_url = var.__zts_url
 

--- a/modules/zone/archive.tf
+++ b/modules/zone/archive.tf
@@ -31,6 +31,13 @@ resource "azurerm_storage_account" "archive" {
     versioning_enabled = false
   }
 
+  # Enforce SMB 3.1.1 for file shares (no file shares are used, this hardens the default).
+  share_properties {
+    smb {
+      versions = ["SMB3.1.1"]
+    }
+  }
+
   # System-assigned identity to provide key vault access
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
The per-zone archive storage account allowed older SMB protocol versions by default. This restricts file-share SMB to 3.1.1+ to align with the Azure security baseline; older SMB versions have known vulnerabilities.

The archive account uses blob storage only (no file shares), so this only hardens the default and has no functional impact.

Partly resolves https://vespaai.atlassian.net/browse/VESPANG-3419

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf` (1.0.29 -> 1.0.30)
- [ ] Minor/internal - no version bump

Verified with `tofu fmt`; the change is a single additive `share_properties.smb` block.

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*